### PR TITLE
WIP Initial exFAT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Currently Teslas only leave the last hour of recent footage on their thumbdrives. However, footage from farther back is easily accessible using basic data recovery techniques.
 
-This repo contains a short script that will scan your entire FAT32 USB drive for MP4s that have been deleted and copies them to a directory for viewing.
+This repo contains a short script that will scan your entire exFAT USB drive for MP4s that have been deleted and copies them to a directory for viewing.
 
 Warning: This is not meant to be a fool-proof guide. This is oriented towards the technically minded with some familiarity with Python and filesystems.
 
@@ -11,7 +11,7 @@ Warning: This is not meant to be a fool-proof guide. This is oriented towards th
 I've only used this on macOS. Linux instructions should be pretty identical. Windows should be pretty close.
 
 * Plug in your USB drive and unmount it.
-* Figure out the device node for your FAT32 partition. On macOS, you can find this in Disk Utility when you click the "Info" button for your volume. It should be something like "disk2s1".
+* Figure out the device node for your exFAT partition. On macOS, you can find this in Disk Utility when you click the "Info" button for your volume. It should be something like "disk2s1".
 * Create a directory for the output.
 * Run the script, providing the directory path and device node like so: `sudo ./run.py /dev/disk2s1 myoutputdirectory`
 

--- a/run.py
+++ b/run.py
@@ -32,18 +32,17 @@ sectorsPerClusterShift,    = struct.unpack("<B", bootSector[0x6D]) # 1 byte, Sim
 reservedSectors,           = struct.unpack("<I", bootSector[0x50:0x54]) # FATOffset, 4 bytes, offset in sectors from the start of the partition to the first FAT
 numberOfFATs,              = struct.unpack("<B", bootSector[0x6E]) # 1 byte
 #maxRootDirEntries,        = struct.unpack("<H", bootSector[0x11:0x13])
-volumeLength,              = struct.unpack("<Q", bootSector[0x48:0x50]) # VolumeLength in Sectors, 8 bytes
+totalSectors,              = struct.unpack("<Q", bootSector[0x48:0x50]) # VolumeLength in Sectors, 8 bytes
 sectorsPerFAT,             = struct.unpack("<I", bootSector[0x54:0x58]) # FATLength, 4 bytes
 #rootDirectoryCluster,      = struct.unpack("<I", bootSector[0x2c:0x30])
 bytesPerSector = 2 ** bytesPerSectorShift
 sectorsPerCluster = 2 ** sectorsPerClusterShift
-totalSectors = volumeLength
 maxRootDirEntries = 0
 
 # if totalSectors == 0:
 #     totalSectors, = struct.unpack("<I", bootSector[0x20:0x24])
 
-totalClusters = volumeLength << sectorsPerClusterShift
+totalClusters = totalSectors/sectorsPerCluster
 bytesPerCluster = bytesPerSector*sectorsPerCluster
 
 print 'Bytes per sector: %d' % bytesPerSector


### PR DESCRIPTION
Tesla now uses exFAT instead of FAT32 for drives formatted by the car. This PR is a horrible hack, but should be at least be functional for finding MP4s on exFAT formatted drives. Hopefully someone can build on this (perhaps even auto-detect the drive format and behave accordingly). Should resolve #2 